### PR TITLE
Remove deprecation messages from Symfony >= 4.3

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -17,8 +17,13 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('byscripts_static_entity');
+        if (\method_exists(TreeBuilder::class, 'getRootNode')) {
+            $treeBuilder = new TreeBuilder('byscripts_static_entity');
+            $rootNode = $treeBuilder->getRootNode();
+        } else {
+            $treeBuilder = new TreeBuilder();
+            $rootNode = $treeBuilder->root('byscripts_static_entity');
+        }
 
         // Here you should define the parameters that are allowed to
         // configure your bundle. See the documentation linked above for


### PR DESCRIPTION
From sf >= 4.3, bundle triggers those depecration warnings :
- "A tree builder without a root node is deprecated since Symfony 4.2 and will not be supported anymore in 5.0."
- "The "Symfony\Component\Config\Definition\Builder\TreeBuilder::root()" method called for the "byscripts_static_entity" configuration is deprecated since Symfony 4.3, pass the root name to the constructor instead."